### PR TITLE
Fix: Lock Mind Elixir version to 4.6.2 via CDN

### DIFF
--- a/wp-mind-elixir-admin.php
+++ b/wp-mind-elixir-admin.php
@@ -79,9 +79,9 @@ function mea_admin_enqueue_scripts( $hook_suffix ) {
         // Mind Elixir library from CDN.
         wp_enqueue_script(
                 'wp-mind-elixir-cdn',
-                'https://cdn.jsdelivr.net/npm/mind-elixir/dist/MindElixir.iife.js',
+                'https://cdn.jsdelivr.net/npm/mind-elixir@4.6.2/dist/MindElixir.iife.js',
                 array(),
-                '4.5.2',
+                '4.6.2',
                 true
         );
         // Our custom JS (depends on jQuery and Mind Elixir).


### PR DESCRIPTION
Previously, the Mind Elixir library was loaded from the CDN without a fixed version,  which could lead to unexpected behavior or bugs when the library is updated.

To ensure stable functionality and prevent future issues,  the version is now explicitly locked to 4.6.2.